### PR TITLE
Added a try catch around 404 client errors

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -33,6 +33,7 @@ from docopt import docopt
 from termcolor import colored
 import configparser
 from scdl import __version__
+from requests.exceptions import HTTPError
 
 import warnings
 import os
@@ -348,7 +349,11 @@ def download_track(track, playlist_name=None):
     global arguments
 
     if track.streamable:
-        stream_url = client.get(track.stream_url, allow_redirects=False)
+        try:
+            stream_url = client.get(track.stream_url, allow_redirects=False)
+        except HTTPError:
+            log('%s track not found...' % (track.title), strverbosity=0)
+            return
     else:
         log('%s is not streamable...' % (track.title), strverbosity=0)
         log('', strverbosity=1)


### PR DESCRIPTION
On a particular song (https://soundcloud.com/theweeknd/the-weeknd-king-of-the-fall)  the `scdl me -f -c` kept failing. I got around it by wrapping it around a try catch and moving on from the error

```py
Traceback (most recent call last):
  File "/Users/zunayed/test_venv/bin/scdl", line 9, in <module>
    load_entry_point('scdl==v1.1.0', 'console_scripts', 'scdl')()
  File "/Users/zunayed/test_venv/lib/python3.4/site-packages/scdl/scdl.py", line 119, in main
    download_user_favorites(who_am_i())
  File "/Users/zunayed/test_venv/lib/python3.4/site-packages/scdl/scdl.py", line 291, in download_user_favorites
    download_track(track)
  File "/Users/zunayed/test_venv/lib/python3.4/site-packages/scdl/scdl.py", line 351, in download_track
    stream_url = client.get(track.stream_url, allow_redirects=False)
  File "/Users/zunayed/test_venv/lib/python3.4/site-packages/soundcloud/client.py", line 130, in _request
    return wrapped_resource(make_request(method, url, kwargs))
  File "/Users/zunayed/test_venv/lib/python3.4/site-packages/soundcloud/request.py", line 135, in make_request
    result.raise_for_status()
  File "/Users/zunayed/test_venv/lib/python3.4/site-packages/requests/models.py", line 831, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found
````

Awesome app btw. Thanks for all making it!